### PR TITLE
add support for account number (in case user has more than one vivacom numbers)

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -6,6 +6,7 @@ from resources.lib.actions import *
 if settings.rebuild_user_data or not settings.guid:
   settings.username = ""
   settings.password = ""
+  settings.account = ""
   settings.rebuild_user_data = False
   settings.open()
   settings.guid = uuid.uuid4()

--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
-<addon id="plugin.video.vivatvgo" name="[COLOR orange]TV GO[/COLOR] Player" version="1.0.11" provider-name="HarryDoubleG">
+<addon id="plugin.video.vivatvgo" name="[COLOR orange]TV GO[/COLOR] Player" version="1.0.12" provider-name="HarryDoubleG">
   <requires>
   	<import addon="xbmc.python" version="2.24.0"/>
     <import addon="script.module.garepobg" version="0.1.4"/>

--- a/resources/lib/helper.py
+++ b/resources/lib/helper.py
@@ -95,12 +95,15 @@ def login():
 
     vivacomSubscribers = res.json()["vivacomSubscribers"] 
     firstActiveSubscription = None
-
+    account = str(settings.account or "default")
+    log(" account: " + account)
+    
     for sub in vivacomSubscribers:
       if sub["subscriberStatus"] == "active":
-        log("Active subscription " + sub["subscriberId"])
+        log("Active subscription " + sub["subscriberId"] + " account: " + account)
         firstActiveSubscription = sub
-        break
+        if (account == "default" or sub["subscriberId"] == account):
+          break
         
     if (firstActiveSubscription == None):
       return "Не е намерен активен абонамент"
@@ -110,6 +113,11 @@ def login():
 
     post_data = {"checksum":settings.checksum,"mac":settings.guid,"subscriberId":settings.subscriberId,"terminaltype":"NoCAAndroidPad","userName":settings.username}
     res = __request(url, post_data)
+
+    if(res.json()["retmsg"] != "success"):
+      log("Error: " + res.json()["retmsg"])
+      return res.json()["retmsg"];
+    
     settings.subscriberPassword = res.json()["users"][0]["password"]
     
     save_cookies(session)

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -3,6 +3,7 @@
 	<category label="Акаунт">
 		<setting id="username" type="text" label="Потребител:" />
 		<setting id="password" type="text" option="hidden" label="Парола:" />
+		<setting id="account" type="text" label="Акаунт номер (опционално):" />
 	</category>
 	<category label="Общи">
     <!-- <setting type="sep"/> -->


### PR DESCRIPTION
Добавена възможност за настройка на номер на акаунт (гсм номер)
полезно е когато някой има повече от един вивакон номер към акаунт и иска да гледа телевизиите не от първият акаунт номер